### PR TITLE
Add platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ git checkout nodejs12.x
 
 Finally you can build your image as such:
 ```
-docker build -t nodejs12.x:local -f Dockerfile.nodejs12.x .
+docker build -t nodejs12.x:local -f Dockerfile.nodejs12.x . --platform linux/amd64
 ```
 
 This will use the Dockerfile at `Dockerfile.nodejs12.x` and tag the newly-built image as `nodejs12.x:local`.


### PR DESCRIPTION
Specify `--platform` argument in `docker build` command to avoid `! python3.8 The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested` warning when creating container on Macs w/ ARM processors